### PR TITLE
Adds support for AsyncStream

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Swift
       uses: swift-actions/setup-swift@v1
       with:
-        swift-version: 5.7
+        swift-version: 5.9
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -14,8 +14,11 @@ let package = Package(
                 name: "FileMonitor",
                 targets: ["FileMonitor"]),
         .executable(
-                name: "FileMonitorExample",
-                targets: ["FileMonitorExample"]
+                name: "FileMonitorDelegateExample",
+                targets: ["FileMonitorDelegateExample"]
+        ),
+        .executable(name: "FileMonitorAsyncStreamExample",
+                    targets: ["FileMonitorAsyncStreamExample"]
         )
     ],
     dependencies: [
@@ -50,7 +53,10 @@ let package = Package(
                 path: "Sources/FileMonitorMacOS"
         ),
         .executableTarget(
-                name: "FileMonitorExample",
+                name: "FileMonitorDelegateExample",
+                dependencies: ["FileMonitor"]),
+        .executableTarget(
+                name: "FileMonitorAsyncStreamExample",
                 dependencies: ["FileMonitor"]),
         .testTarget(
             name: "FileMonitorTests",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ FileMonitor focuses on monitoring file changes within a given directory. It offe
 - Detection of file creations
 - Detection of file modifications
 - Detection of file deletions
+- AsyncStream delivery of detections
 
 All events are propagated through a delegate function using a switchable enum type.
 
@@ -40,7 +41,32 @@ Don't forget to add the product "FileMonitor" as a dependency for your target:
 ```
 
 ## Usage
-To use FileMonitor, follow this example:
+### Use with AsyncStream
+Example usage:
+```swift
+import FileMonitor
+import Foundation
+
+struct FileMonitorExample: FileDidChangeDelegate {
+    init() throws {
+        let dir = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Downloads")
+        let monitor = try FileMonitor(directory: dir, delegate: self )
+        try monitor.start()
+        for await event in monitor.stream {
+            switch event {
+            case .added(let file):
+                print("New file \(file.path)")
+            default:
+                print("\(event)")
+            }
+        }
+    }
+}
+```
+
+
+### Use as a Delegate
+Example usage:
 
 ```swift
 import FileMonitor

--- a/Sources/FileMonitor/FileMonitor.swift
+++ b/Sources/FileMonitor/FileMonitor.swift
@@ -21,6 +21,7 @@ public enum FileMonitorErrors: Error {
 
 /// FileMonitor: Watch for file changes in a directory with a unified API on Linux and macOS.
 public struct FileMonitor: WatcherDelegate {
+    public let (stream, continuation) = AsyncStream.makeStream(of: FileChange.self)
 
     var watcher: WatcherProtocol
     public var delegate: FileDidChangeDelegate? {
@@ -67,6 +68,7 @@ public struct FileMonitor: WatcherDelegate {
     ///   - Error
     public func stop() {
         watcher.stop()
+        continuation.finish()
     }
 
     // MARK: - WatcherDelegate
@@ -76,6 +78,7 @@ public struct FileMonitor: WatcherDelegate {
     /// - Parameter event: A file change event
     public func fileDidChanged(event: FileChangeEvent) {
         delegate?.fileDidChanged(event: event)
+        continuation.yield(event)
     }
 
 }

--- a/Sources/FileMonitor/FileMonitor.swift
+++ b/Sources/FileMonitor/FileMonitor.swift
@@ -21,7 +21,10 @@ public enum FileMonitorErrors: Error {
 
 /// FileMonitor: Watch for file changes in a directory with a unified API on Linux and macOS.
 public struct FileMonitor: WatcherDelegate {
-    public let (stream, continuation) = AsyncStream.makeStream(of: FileChange.self)
+    private let fileChangeStream = AsyncStream.makeStream(of: FileChange.self)
+    public var stream: AsyncStream<FileChange> {
+        fileChangeStream.stream
+    }
 
     var watcher: WatcherProtocol
     public var delegate: FileDidChangeDelegate? {
@@ -68,7 +71,7 @@ public struct FileMonitor: WatcherDelegate {
     ///   - Error
     public func stop() {
         watcher.stop()
-        continuation.finish()
+        fileChangeStream.continuation.finish()
     }
 
     // MARK: - WatcherDelegate
@@ -78,7 +81,7 @@ public struct FileMonitor: WatcherDelegate {
     /// - Parameter event: A file change event
     public func fileDidChanged(event: FileChangeEvent) {
         delegate?.fileDidChanged(event: event)
-        continuation.yield(event)
+        fileChangeStream.continuation.yield(event)
     }
 
 }

--- a/Sources/FileMonitorAsyncStreamExample/FileMonitorAsyncStreamExample.swift
+++ b/Sources/FileMonitorAsyncStreamExample/FileMonitorAsyncStreamExample.swift
@@ -6,13 +6,14 @@
 import Foundation
 import FileMonitor
 
+/// This example shows how to use `FileMonitor`’s AsyncStream with Swift  Structured Concurrency
 @main
-public struct FileMonitorExample: FileDidChangeDelegate {
+public struct FileMonitorAsyncStreamExample {
 
     /// Main entrypoint
     /// Start FileMonitorExample with an argument to the monitored directory
     /// - Throws: an error when the FileMonitor can't be initialized
-    public static func main() throws {
+    public static func main() async throws {
         let arguments = CommandLine.arguments
         if arguments.count < 2 {
             print("One folder should be provided at least.")
@@ -24,29 +25,22 @@ public struct FileMonitorExample: FileDidChangeDelegate {
             exit(1)
         }
 
-        let fileMonitor = FileMonitorExample()
-        try fileMonitor.run(on: folderToWatch);
+        let fileMonitor = FileMonitorAsyncStreamExample()
+        try await fileMonitor.run(on: folderToWatch)
     }
 
     /// Run a file monitor on a given folder
     ///
     /// - Parameter folder: A URL of a directory
     /// - Throws: an error when the FileMonitor can't be initialized
-    func run(on folder: URL) throws {
+    func run(on folder: URL) async throws {
         print("Monitoring files in \(folder.standardized.path)")
 
-        let monitor = try FileMonitor(directory: folder.standardized, delegate: self )
-        try monitor.start();
-
-        RunLoop.main.run()
-    }
-
-    // MARK: - Delegate FileDidChanged
-
-    /// Called when a file change event occurs
-    ///
-    /// - Parameter event: A FileChange event
-    public func fileDidChanged(event: FileChange) {
-        print("\(event.description)")
+        let monitor = try FileMonitor(directory: folder.standardized)
+        try monitor.start()
+        // MARK: - AsyncStream
+        for await event in monitor.stream {
+            print("Stream: \(event.description)")
+        }
     }
 }

--- a/Sources/FileMonitorDelegateExample/FileMonitorDelegateExample.swift
+++ b/Sources/FileMonitorDelegateExample/FileMonitorDelegateExample.swift
@@ -1,0 +1,51 @@
+//
+// aus der Technik, on 17.05.23.
+// https://www.ausdertechnik.de
+//
+
+import Foundation
+import FileMonitor
+
+/// This example shows how to use `FileMonitor` as a Delegate-callback system (without Structured Concurrency)
+@main
+public struct FileMonitorDelegateExample: FileDidChangeDelegate {
+
+    /// Main entrypoint
+    /// Start FileMonitorExample with an argument to the monitored directory
+    /// - Throws: an error when the FileMonitor can't be initialized
+    public static func main() async throws {
+        let arguments = CommandLine.arguments
+        if arguments.count < 2 {
+            print("One folder should be provided at least.")
+            print("Run \(arguments.first ?? "program") <folder>")
+            exit(1)
+        }
+        guard let folderToWatch = URL(string: arguments[1]) else {
+            print("Folder '\(arguments[1])' is not an valid location.")
+            exit(1)
+        }
+
+        let fileMonitor = FileMonitorDelegateExample()
+        try await fileMonitor.run(on: folderToWatch)
+    }
+
+    /// Run a file monitor on a given folder
+    ///
+    /// - Parameter folder: A URL of a directory
+    /// - Throws: an error when the FileMonitor can't be initialized
+    func run(on folder: URL) async throws {
+        print("Monitoring files in \(folder.standardized.path)")
+
+        let monitor = try FileMonitor(directory: folder.standardized, delegate: self )
+        try monitor.start()
+    }
+
+    // MARK: - Delegate FileDidChanged
+
+    /// Called when a file change event occurs
+    ///
+    /// - Parameter event: A FileChange event
+    public func fileDidChanged(event: FileChange) {
+        print("Callback: \(event.description)")
+    }
+}


### PR DESCRIPTION
This PR:
- Adds `AsyncStream` support to `FileMonitor` for modern Swift Structured Concurrency support
- Bumps the Package build requirement to 5.9, breaking backward compatibility

Benefits:
Users can change callback based system with `for await event in fileMonitor.stream { ... }`

Drawbacks:
I have forced the Package to use Swift 5.9 instead of using `#available` or `@available`. We could use an availability check to avoid breaking backward compatibility. OR we could release a new, breaking release of this Package using Github releases.

I’m open to either approach, but we should pick one.